### PR TITLE
Fixed denormalization of nested non entity objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import ArraySchema from 'normalizr/lib/IterableSchema';
 import EntitySchema from 'normalizr/lib/EntitySchema';
 import UnionSchema from 'normalizr/lib/UnionSchema';
 import merge from "lodash/merge";
+import isPlainObject from "lodash/isPlainObject";
 
 function getItem(id, key, schema, entities, bag) {
   if(!bag.hasOwnProperty(key)) {
@@ -15,6 +16,9 @@ function getItem(id, key, schema, entities, bag) {
 
 function denormalizeArray(items, entities, schema, bag) {
   const itemSchema = schema.getItemSchema();
+  if (isPlainObject(itemSchema)) {
+    return items.map(o => denormalize(o, entities, itemSchema, bag));
+  }
   const itemKey = itemSchema.getKey();
   return items.map(id => getItem(id, itemKey, itemSchema, entities, bag));
 }

--- a/test/index.js
+++ b/test/index.js
@@ -177,4 +177,51 @@ describe("denormalize", () => {
     });
   });
 
+  describe("parsing nested plain objects", () => {
+
+    const articleSchema = new Schema("article");
+    const userSchema = new Schema("user");
+
+    articleSchema.define({
+      likes: arrayOf({
+        user: userSchema
+      })
+    });
+
+    const response = {
+      articles: [{
+        id: 1,
+        title: "Article 1",
+        likes: [{
+          user: {
+            id: 1,
+            name: "John"
+          }
+        }, {
+          user: {
+            id: 2,
+            name: "Alex"
+          }
+        }]
+      }, {
+        id: 2,
+        title: "Article 2",
+        likes: [{
+          user: {
+            id: 1,
+            name: "John"
+          }
+        }]
+      }]
+    };
+
+    const data = normalize(response.articles, arrayOf(articleSchema));
+
+    it("should denormalize nested non entity objects", () => {
+      const denormalized = data.result.map(id => denormalize(data.entities.article[id], data.entities, articleSchema));
+      expect(denormalized).to.be.deep.eql(response.articles);
+    });
+    
+  });
+
 });


### PR DESCRIPTION
Added support for nested non entity object schemas, for example: 

```js
const articleSchema = new Schema("article");
const userSchema = new Schema("user");

articleSchema.define({
  likes: arrayOf({
    user: userSchema
  })
});
```
In the current implementation an error is thrown when trying to denormalize array of likes: `itemSchema.getKey is not a function`