### PR TITLE
Fixed denormalization of nested non plain objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,14 +56,16 @@ export function denormalize(entity, entities, entitySchema, bag = {}) {
         return;
       }
 
-      const itemId = entity[attribute];
+      const item = entity[attribute];
 
       if (entitySchema[attribute] instanceof ArraySchema) {
-        denormalized[attribute] = denormalizeArray(itemId, entities, entitySchema[attribute], bag);
+        denormalized[attribute] = denormalizeArray(item, entities, entitySchema[attribute], bag);
       } else if (entitySchema[attribute] instanceof EntitySchema) {
         const itemSchema = entitySchema[attribute];
         const itemKey = itemSchema.getKey();
-        denormalized[attribute] = getItem(itemId, itemKey, itemSchema, entities, bag);
+        denormalized[attribute] = getItem(item, itemKey, itemSchema, entities, bag);
+      } else {
+        denormalized[attribute] = denormalize(item, entities, entitySchema[attribute], bag);
       }
 
     });

--- a/test/index.js
+++ b/test/index.js
@@ -224,4 +224,54 @@ describe("denormalize", () => {
     
   });
 
+  describe("parsing nested objects", () => {
+
+    const articleSchema = new Schema("article");
+    const userSchema = new Schema("user");
+
+    articleSchema.define({
+      likes: {
+        usersWhoLikes: arrayOf( userSchema )
+      }
+    });
+
+    const response = {
+      articles: [{
+        id: 1,
+        title: "Article 1",
+        likes: {
+          usersWhoLikes: [
+          {
+            id: 1,
+            name: "John"
+          },
+          {
+            id: 2,
+            name: "Alex"
+          }
+          ]
+        }
+      }, {
+        id: 2,
+        title: "Article 2",
+        likes: {
+          usersWhoLikes: [
+          {
+            id: 1,
+            name: "John"
+          }
+          ]
+        }
+      }]
+    };
+
+    const data = normalize(response.articles, arrayOf(articleSchema));
+
+    it("should denormalize nested non entity objects recursively", () => {
+      const denormalized = data.result.map(id => denormalize(data.entities.article[id], data.entities, articleSchema));
+      expect(denormalized).to.be.deep.eql(response.articles);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Added support to denormalize deeply nested objects, for example:

```javascript
    const articleSchema = new Schema("article");
    const userSchema = new Schema("user");

    articleSchema.define({
      likes: {
        usersWhoLikes: arrayOf( userSchema )
      }
    });
```

data:
```javascript
{
articles: [{
        id: 1,
        title: "Article 1",
        likes: {
          usersWhoLikes: [
          {
            id: 1,
            name: "John"
          },
          {
            id: 2,
            name: "Alex"
          }
          ]
        }
      }]
}
``` 
The current implementation denormalizes only first level attributes. Due to this, the denormalize function returns ``{ articles: [ { id: 1, title: 'Article 1', likes: { usersWhoLikes: [ 1, 2 ] } } ] }``  (`likes` attribute is denormalized as a non entity object). Applying this fix,  denormalize function returns the original data.