### PR TITLE
Add support for immutable-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This module is useful when consuming normalized data, e.g. from `mapStateToProps
 
 [![build status](https://img.shields.io/travis/gpbl/denormalizr/master.svg?style=flat-square)](https://travis-ci.org/gpbl/denormalizr) [![Code Climate](https://img.shields.io/codeclimate/github/gpbl/denormalizr.svg?style=flat-square)](https://codeclimate.com/github/gpbl/denormalizr) [![npm downloads](https://img.shields.io/npm/dm/denormalizr.svg?style=flat-square)](https://www.npmjs.com/package/denormalizr) [![npm version](https://img.shields.io/npm/v/denormalizr.svg?style=flat-square)](https://www.npmjs.com/package/denormalizr)
 
-> If you are using Immutable data, try [denormalizr-immutable](https://github.com/dehbmarques/denormalizr-immutable).
-
 ## Installation
 
 ```
@@ -74,3 +72,22 @@ console.log(denormalized);
 // }
 
 ```
+
+## Usage with Immutable
+
+This package works with immutable-js, however there's a slight difference in how circular references are handled:
+
+- When using non-immutable data structures, circular references are fully supported (see: https://github.com/gpbl/denormalizr/pull/2). So:
+```javascript
+// The nested article contains a complete reference back to the `denormalized.author` object
+denormalized.author.articles[0].author === denormalized.author.articles[0].author.articles[0].author
+```
+- Circular references is something that immutable-js does not support (and [does not plan to support](https://github.com/facebook/immutable-js/issues/259)). When a circular reference is reached, the non-denormalized copy is returned. So:
+So:
+```javascript
+// The nested article only contains a reference to the author by ID
+denormalized.author.articles[0].author === 1
+```
+
+Related work:
+* [denormalizr-immutable](https://github.com/dehbmarques/denormalizr-immutable).

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "babel-eslint": "6.0.0-beta.6",
     "babel-preset-es2015": "^6.6.0",
     "chai": "^3.5.0",
+    "chai-immutable": "^1.5.4",
     "eslint": "^2.4.0",
+    "immutable": "^3.8.1",
     "mocha": "^2.4.5",
     "rimraf": "^2.5.2"
   },

--- a/src/immutable_helpers.js
+++ b/src/immutable_helpers.js
@@ -1,0 +1,62 @@
+import reduce from 'lodash/reduce';
+
+/**
+ * Helpers to enable Immutable-JS compatibility.
+ */
+
+function stringifiedArray(array) {
+  return array.map((item) => item && item.toString())
+}
+
+/**
+ * To avoid including immutable-js as a dependency, check if an object is
+ * immutable by checking if it implements the getIn method.
+ *
+ * @param  {any} object
+ * @return {bool}
+ */
+export function isImmutable(object) {
+  return !!object.getIn
+}
+
+/**
+ * If the object responds to getIn, that's called directly. Otherwise
+ * recursively apply object/array access to get the value.
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @param  {Array<string, number>} keyPath
+ * @return {any}
+ */
+export function getIn (object, keyPath) {
+  if (object.getIn) {
+    return object.getIn(stringifiedArray(keyPath))
+  }
+
+  return reduce(
+    keyPath,
+    (memo, key) => memo[key],
+    object
+  )
+}
+
+/**
+ * If the object responds to setIn, that's called directly. Otherwise
+ * recursively apply object/array access and set the value at that location.
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @param  {Array<string, number>} keyPath
+ * @param  {any} value
+ * @return {any}
+ */
+export function setIn (object, keyPath, value) {
+  if (object.setIn) {
+    return object.setIn(stringifiedArray(keyPath), value)
+  }
+
+  const lastKey = keyPath.pop()
+  const location = getIn(object, keyPath)
+
+  location[lastKey] = value
+
+  return object
+}

--- a/test/immutable.spec.js
+++ b/test/immutable.spec.js
@@ -1,0 +1,293 @@
+/* eslint-env mocha */
+
+import chai from "chai";
+
+import { denormalize } from "../src";
+import { normalize, Schema, arrayOf, unionOf } from 'normalizr';
+import { fromJS } from 'immutable';
+
+import chaiImmutable from 'chai-immutable'
+chai.use(chaiImmutable)
+const expect = chai.expect
+
+const immutableNormalize = (response, schema) => {
+  const { entities, result } = normalize(response, schema)
+
+  return {
+    entities: fromJS(entities),
+    result
+  }
+}
+
+describe("denormalize", () => {
+
+  it("should return undefined when denormalizing an undefined entity", () => {
+    expect(denormalize(undefined)).to.be.undefined;
+  });
+
+
+  describe("parsing entities and collections", () => {
+    const articleSchema = new Schema('articles');
+    const userSchema = new Schema('users');
+    const collectionSchema = new Schema('collections');
+
+    articleSchema.define({
+      author: userSchema,
+      collections: arrayOf(collectionSchema)
+    });
+
+    collectionSchema.define({
+      curator: userSchema
+    });
+
+    const article1 = {
+      id: 1,
+      title: 'Some Article',
+      author: {
+        id: 1,
+        name: 'Dan'
+      },
+      collections: [{
+        id: 1,
+        name: 'Dan'
+      }, {
+        id: 2,
+        name: 'Giampaolo'
+      }]
+    };
+    const article2 = {
+      id: 2,
+      title: 'Other Article',
+      author: {
+        id: 1,
+        name: 'Dan'
+      }
+    };
+    const article3 = {
+      id: 3,
+      title: 'Without author',
+      author: null
+    };
+
+    const article4 = {
+      id: 4,
+      title: 'Some Article',
+      author: {
+        id: '',
+        name: 'Deleted'
+      },
+      collections: [{
+        id: '',
+        name: 'Deleted'
+      }]
+    };
+
+    const response = {
+      articles: [article1, article2, article3, article4]
+    };
+
+    const data = immutableNormalize(response, {
+      articles: arrayOf(articleSchema)
+    });
+
+    it("should return the original entity", () => {
+      const article = data.entities.getIn(["articles", "1"]);
+      expect(denormalize(article, data.entities, articleSchema)).to.be.eql(fromJS(article1));
+    });
+
+    it("should work with entities without values", () => {
+      const article = data.entities.getIn(["articles", "3"]);
+      expect(denormalize(article, data.entities, articleSchema)).to.be.eql(fromJS(article3));
+    });
+
+    it("should work with entities with empty id", () => {
+      const article = data.entities.getIn(["articles", "4"]);
+      expect(denormalize(article, data.entities, articleSchema)).to.be.eql(fromJS(article4));
+    });
+
+
+  });
+
+  describe("parsing interdependents objects", () => {
+    const articleSchema = new Schema('articles');
+    const userSchema = new Schema('users');
+
+    articleSchema.define({
+      author: userSchema,
+    });
+
+    userSchema.define({
+      articles: arrayOf(articleSchema),
+    });
+
+    const response = {
+      articles: [{
+        id: 80,
+        title: 'Some Article',
+        author: {
+          id: 1,
+          name: 'Dan',
+          articles: [80],
+        }
+      }]
+    };
+
+    const data = immutableNormalize(response, {
+      articles: arrayOf(articleSchema)
+    });
+
+    // This behavior differs from non-immutable functionality. See the README
+    // for more details.
+    it("should handle recursion for interdependency", () => {
+      const article = data.entities.getIn(["articles", "80"]);
+      const denormalized = denormalize(article, data.entities, articleSchema);
+
+      expect(denormalized.getIn(['author', 'articles', '0'])).to.be.eql(article);
+    });
+
+  });
+
+  describe("parsing union schemas", () => {
+
+    const postSchema = new Schema('posts');
+    const userSchema = new Schema('users');
+
+    postSchema.define({
+      user: userSchema
+    });
+
+    const unionItemSchema = unionOf({
+      post: postSchema,
+      user: userSchema
+    }, { schemaAttribute: 'type' });
+
+    const response = {
+      unionItems: [
+        {
+          id: 1,
+          title: 'Some Post',
+          user: {
+            id: 1,
+            name: 'Dan'
+          },
+          type: 'post'
+        },
+        {
+          id: 2,
+          name: 'Ashley',
+          type: 'user'
+        },
+        {
+          id: 2,
+          title: 'Other Post',
+          type: 'post'
+        }
+      ]
+    };
+
+    const data = immutableNormalize(response.unionItems, arrayOf(unionItemSchema));
+
+    it("should return the original response", () => {
+      const denormalized = data.result.map(item => denormalize(item, data.entities, unionItemSchema));
+      expect(fromJS(denormalized)).to.be.eql(fromJS(response.unionItems));
+    });
+  });
+
+  describe("parsing nested plain objects", () => {
+
+    const articleSchema = new Schema("article");
+    const userSchema = new Schema("user");
+
+    articleSchema.define({
+      likes: arrayOf({
+        user: userSchema
+      })
+    });
+
+    const response = {
+      articles: [{
+        id: 1,
+        title: "Article 1",
+        likes: [{
+          user: {
+            id: 1,
+            name: "John"
+          }
+        }, {
+          user: {
+            id: 2,
+            name: "Alex"
+          }
+        }]
+      }, {
+        id: 2,
+        title: "Article 2",
+        likes: [{
+          user: {
+            id: 1,
+            name: "John"
+          }
+        }]
+      }]
+    };
+
+    const data = immutableNormalize(response.articles, arrayOf(articleSchema));
+
+    it("should denormalize nested non entity objects", () => {
+      const denormalized = data.result.map(id => denormalize(data.entities.getIn(['article', id.toString()]), data.entities, articleSchema));
+      expect(fromJS(denormalized)).to.be.deep.eql(fromJS(response.articles));
+    });
+
+  });
+
+  describe("parsing nested objects", () => {
+
+    const articleSchema = new Schema("article");
+    const userSchema = new Schema("user");
+
+    articleSchema.define({
+      likes: {
+        usersWhoLikes: arrayOf( userSchema )
+      }
+    });
+
+    const response = {
+      articles: [{
+        id: 1,
+        title: "Article 1",
+        likes: {
+          usersWhoLikes: [
+          {
+            id: 1,
+            name: "John"
+          },
+          {
+            id: 2,
+            name: "Alex"
+          }
+          ]
+        }
+      }, {
+        id: 2,
+        title: "Article 2",
+        likes: {
+          usersWhoLikes: [
+          {
+            id: 1,
+            name: "John"
+          }
+          ]
+        }
+      }]
+    };
+
+    const data = immutableNormalize(response.articles, arrayOf(articleSchema));
+
+    it("should denormalize nested non entity objects recursively", () => {
+      const denormalized = data.result.map(id => denormalize(data.entities.getIn(['article', id.toString()]), data.entities, articleSchema));
+      expect(fromJS(denormalized)).to.be.deep.eql(fromJS(response.articles));
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adds support for immutable-js without actually requiring it as a dependency.

Support is handled by using simple `getIn`, `setIn` methods that defer to the immutable implementations if the object is immutable otherwise implement the same behavior on plain javascript objects/arrays. `immutable-js` is required as a dev dependency since it's needed for specs. I just copied the existing specs and adapted them to work with immutable.

One thing to note (which I added to the README): Circular references is something that `immutable-js` does not support (and [does not plan to support](https://github.com/facebook/immutable-js/issues/259)). When a circular reference is reached, the non-denormalized copy is returned. So:
```javascript
// The nested article only contains a reference to the author by ID
denormalized.author.articles[0].author === 1
```