### PR TITLE
Denormalize arrays, ids, and arrays of ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,42 @@ console.log(denormalized);
 //   },
 // }
 
+// Denormalize a list
+const denormalized = denormalize([article], normalized.entities, articleSchema);
+console.log(denormalized);
+// [{
+//   id: 1,
+//   title: 'Some Article',
+//   author: {
+//     id: 1,
+//     name: 'Dan'
+//   },
+// }]
+
+// Denormalize by passing just the ID
+const denormalized = denormalize(1, normalized.entities, articleSchema);
+console.log(denormalized);
+// {
+//   id: 1,
+//   title: 'Some Article',
+//   author: {
+//     id: 1,
+//     name: 'Dan'
+//   },
+// }
+
+// Denormalize by passing a list of IDs
+const denormalized = denormalize([1], normalized.entities, articleSchema);
+console.log(denormalized);
+// [{
+//   id: 1,
+//   title: 'Some Article',
+//   author: {
+//     id: 1,
+//     name: 'Dan'
+//   },
+// }]
+
 ```
 
 ## Usage with Immutable

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,55 @@
-import ArraySchema from 'normalizr/lib/IterableSchema';
+import IterableSchema from 'normalizr/lib/IterableSchema';
 import EntitySchema from 'normalizr/lib/EntitySchema';
 import UnionSchema from 'normalizr/lib/UnionSchema';
-import merge from "lodash/merge";
-import isPlainObject from "lodash/isPlainObject";
+import merge from 'lodash/merge';
+import isObject from 'lodash/isObject';
 import { isImmutable, getIn, setIn } from './immutable_helpers'
 
-function getItem(id, key, schema, entities, bag) {
-  if(!bag.hasOwnProperty(key)) {
-    bag[key] = {};
+/**
+ * Take either an entity or id and derive the other.
+ *
+ * @param   {object|Immutable.Map|number|string} entityOrId
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @returns {object}
+ */
+function resolveEntityOrId(entityOrId, entities, schema) {
+  const key = schema.getKey();
+
+  let entity = entityOrId
+  let id = entityOrId
+
+  if (isObject(entityOrId)) {
+    id = getIn(entity, [schema.getIdAttribute()])
+  } else {
+    entity = getIn(entities, [key, id])
   }
-  if(!bag[key].hasOwnProperty(id)) {
-    bag[key][id] = denormalize(getIn(entities, [key, id]), entities, schema, bag);
-  }
-  return bag[key][id];
+
+  return { entity, id }
 }
 
-function denormalizeArray(items, entities, schema, bag) {
+/**
+ * Denormalizes each entity in the given array.
+ *
+ * @param   {Array|Immutable.List} items
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {Array|Immutable.List}
+ */
+function denormalizeIterable(items, entities, schema, bag) {
   const itemSchema = schema.getItemSchema();
-  if (isPlainObject(itemSchema)) {
-    return items.map(o => denormalize(o, entities, itemSchema, bag));
-  }
-  const itemKey = itemSchema.getKey();
-  return items.map(id => getItem(id, itemKey, itemSchema, entities, bag));
+
+  return items.map(o => denormalize(o, entities, itemSchema, bag));
 }
 
+/**
+ * @param   {object|Immutable.Map|number|string} entity
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map}
+ */
 function denormalizeUnion(entity, entities, schema, bag) {
   const itemSchema = schema.getItemSchema();
   return denormalize(
@@ -34,42 +60,95 @@ function denormalizeUnion(entity, entities, schema, bag) {
   )[entity.schema];
 }
 
-export function denormalize(entity, entities, entitySchema, bag = {}) {
-  if (typeof entity === 'undefined') {
-    return entity;
-  }
-  let denormalized = isImmutable(entity) ? entity : merge({}, entity)
-  if (entitySchema instanceof UnionSchema) {
-    return denormalizeUnion(entity, entities, entitySchema, bag);
-  }
-  if (entitySchema instanceof EntitySchema) {
-    const key = entitySchema.getKey();
-    const id = getIn(denormalized, [entitySchema.getIdAttribute()]);
-    bag[key] = Object.assign(bag[key] || {}, {[id]: denormalized});
-  }
-  Object.keys(entitySchema)
-    .filter(attribute => attribute.substring(0, 1) !== "_")
-    .filter(attribute => typeof getIn(entity, [attribute]) !== 'undefined')
+/**
+ * Takes an object and denormalizes it.
+ *
+ * Note: For non-immutable objects, this will mutate the object. This is
+ * necessary for handling circular dependencies. In order to not mutate the
+ * original object, the caller should copy the object before passing it here.
+ *
+ * @param   {object|Immutable.Map} obj
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map}
+ */
+function denormalizeObject(obj, entities, schema, bag) {
+  let denormalized = obj
+
+  Object.keys(schema)
+    .filter(attribute => attribute.substring(0, 1) !== '_')
+    .filter(attribute => typeof getIn(obj, [attribute]) !== 'undefined')
     .forEach(attribute => {
 
-      if (getIn(entity, [attribute]) === null) {
-        denormalized = setIn(denormalized, [attribute], null);
-        return;
-      }
+      const item = getIn(obj, [attribute]);
+      const itemSchema = getIn(schema, [attribute]);
 
-      const item = getIn(entity, [attribute]);
-
-      if (entitySchema[attribute] instanceof ArraySchema) {
-        denormalized = setIn(denormalized, [attribute], denormalizeArray(item, entities, entitySchema[attribute], bag));
-      } else if (entitySchema[attribute] instanceof EntitySchema) {
-        const itemSchema = entitySchema[attribute];
-        const itemKey = itemSchema.getKey();
-        denormalized = setIn(denormalized, [attribute], getItem(item, itemKey, itemSchema, entities, bag));
-      } else {
-        denormalized = setIn(denormalized, [attribute], denormalize(item, entities, entitySchema[attribute], bag));
-      }
-
+      denormalized = setIn(denormalized, [attribute], denormalize(item, entities, itemSchema, bag));
     });
 
   return denormalized;
+}
+
+/**
+ * Takes an entity, saves a reference to it in the 'bag' and then denormalizes
+ * it. Saving the reference is necessary for circular dependencies.
+ *
+ * @param   {object|Immutable.Map|number|string} entityOrId
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map}
+ */
+function denormalizeEntity(entityOrId, entities, schema, bag) {
+  const key = schema.getKey();
+  const { entity, id} = resolveEntityOrId(entityOrId, entities, schema)
+
+  if(!bag.hasOwnProperty(key)) {
+    bag[key] = {};
+  }
+
+  if(!bag[key].hasOwnProperty(id)) {
+    // Ensure we don't mutate it non-immutable objects
+    const obj = isImmutable(entity) ? entity : merge({}, entity)
+
+    // Need to set this first so that if it is referenced within the call to
+    // denormalizeObject, it will already exist.
+    bag[key][id] = obj;
+    bag[key][id] = denormalizeObject(obj, entities, schema, bag);
+  }
+
+  return bag[key][id];
+}
+
+/**
+ * Takes an object, array, or id and returns a denormalized copy of it. For
+ * an object or array, the same data type is returned. For an id, an object
+ * will be returned.
+ *
+ * If the passed object is null or undefined or if no schema is provided, the
+ * passed object will be returned.
+ *
+ * @param   {object|Immutable.Map|array|Immutable.list|number|string} obj
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map|array|Immutable.list}
+ */
+export function denormalize(obj, entities, schema, bag = {}) {
+  if (obj === null || typeof obj === 'undefined' || !isObject(schema)) {
+    return obj;
+  }
+
+  if (schema instanceof EntitySchema) {
+    return denormalizeEntity(obj, entities, schema, bag);
+  } else if (schema instanceof IterableSchema) {
+    return denormalizeIterable(obj, entities, schema, bag);
+  } else if (schema instanceof UnionSchema) {
+    return denormalizeUnion(obj, entities, schema, bag);
+  } else {
+    // Ensure we don't mutate it non-immutable objects
+    const entity = isImmutable(obj) ? obj : merge({}, obj)
+    return denormalizeObject(entity, entities, schema, bag);
+  }
 }


### PR DESCRIPTION
Fixes #3 

This PR updates the denormalize function to handle denormalizing lists when the schema is an `IterableSchema` (i.e. `arrayOf(someEntitySchema)`). I did some refactoring as part of that work, and a nice side effect was being able to denormalize just by passing the id (or array of ids). This was already how denormalizing nested arrays was handled, so I think it makes sense to expose at the top level.

A cool side effect is the greater symmetry with normalizr. This is now true:

```js
const { result, entities } = normalize(response, schema);
denormalize(result, entities, schema) == response
```