### PR TITLE
Add support for computed properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
-lib

--- a/lib/ImmutableUtils.js
+++ b/lib/ImmutableUtils.js
@@ -1,0 +1,75 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.isImmutable = isImmutable;
+exports.getIn = getIn;
+exports.setIn = setIn;
+
+var _reduce = require('lodash/reduce');
+
+var _reduce2 = _interopRequireDefault(_reduce);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Helpers to enable Immutable-JS compatibility.
+ */
+
+function stringifiedArray(array) {
+  return array.map(function (item) {
+    return item && item.toString();
+  });
+}
+
+/**
+ * To avoid including immutable-js as a dependency, check if an object is
+ * immutable by checking if it implements the getIn method.
+ *
+ * @param  {any} object
+ * @return {bool}
+ */
+function isImmutable(object) {
+  return object && !!object.getIn;
+}
+
+/**
+ * If the object responds to getIn, that's called directly. Otherwise
+ * recursively apply object/array access to get the value.
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @param  {Array<string, number>} keyPath
+ * @return {any}
+ */
+function getIn(object, keyPath) {
+  if (object.getIn) {
+    return object.getIn(stringifiedArray(keyPath));
+  }
+
+  return (0, _reduce2.default)(keyPath, function (memo, key) {
+    return memo[key];
+  }, object);
+}
+
+/**
+ * If the object responds to setIn, that's called directly. Otherwise
+ * recursively apply object/array access and set the value at that location.
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @param  {Array<string, number>} keyPath
+ * @param  {any} value
+ * @return {any}
+ */
+function setIn(object, keyPath, value) {
+  if (object.setIn) {
+    return object.setIn(stringifiedArray(keyPath), value);
+  }
+
+  var lastKey = keyPath.pop();
+  var location = getIn(object, keyPath);
+
+  location[lastKey] = value;
+
+  return object;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,192 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.denormalize = denormalize;
+
+var _IterableSchema = require('normalizr/lib/IterableSchema');
+
+var _IterableSchema2 = _interopRequireDefault(_IterableSchema);
+
+var _EntitySchema = require('normalizr/lib/EntitySchema');
+
+var _EntitySchema2 = _interopRequireDefault(_EntitySchema);
+
+var _UnionSchema = require('normalizr/lib/UnionSchema');
+
+var _UnionSchema2 = _interopRequireDefault(_UnionSchema);
+
+var _merge = require('lodash/merge');
+
+var _merge2 = _interopRequireDefault(_merge);
+
+var _isObject = require('lodash/isObject');
+
+var _isObject2 = _interopRequireDefault(_isObject);
+
+var _ImmutableUtils = require('./ImmutableUtils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/**
+ * Take either an entity or id and derive the other.
+ *
+ * @param   {object|Immutable.Map|number|string} entityOrId
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @returns {object}
+ */
+function resolveEntityOrId(entityOrId, entities, schema) {
+  var key = schema.getKey();
+
+  var entity = entityOrId;
+  var id = entityOrId;
+
+  if ((0, _isObject2.default)(entityOrId)) {
+    id = (0, _ImmutableUtils.getIn)(entity, [schema.getIdAttribute()]);
+  } else {
+    entity = (0, _ImmutableUtils.getIn)(entities, [key, id]);
+  }
+
+  return { entity: entity, id: id };
+}
+
+/**
+ * Denormalizes each entity in the given array.
+ *
+ * @param   {Array|Immutable.List} items
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {Array|Immutable.List}
+ */
+function denormalizeIterable(items, entities, schema, bag) {
+  var itemSchema = schema.getItemSchema();
+
+  return items.map(function (o) {
+    return denormalize(o, entities, itemSchema, bag);
+  });
+}
+
+/**
+ * @param   {object|Immutable.Map|number|string} entity
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map}
+ */
+function denormalizeUnion(entity, entities, schema, bag) {
+  var itemSchema = schema.getItemSchema();
+  return denormalize(Object.assign({}, entity, _defineProperty({}, entity.schema, entity.id)), entities, itemSchema, bag)[entity.schema];
+}
+
+/**
+ * Takes an object and denormalizes it.
+ *
+ * Note: For non-immutable objects, this will mutate the object. This is
+ * necessary for handling circular dependencies. In order to not mutate the
+ * original object, the caller should copy the object before passing it here.
+ *
+ * @param   {object|Immutable.Map} obj
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map}
+ */
+function denormalizeObject(obj, entities, schema, bag) {
+  var denormalized = obj;
+
+  Object.keys(schema).filter(function (attribute) {
+    return attribute.substring(0, 1) !== '_';
+  }).filter(function (attribute) {
+    return typeof (0, _ImmutableUtils.getIn)(obj, [attribute]) !== 'undefined';
+  }).forEach(function (attribute) {
+
+    var item = (0, _ImmutableUtils.getIn)(obj, [attribute]);
+    var itemSchema = (0, _ImmutableUtils.getIn)(schema, [attribute]);
+
+    denormalized = (0, _ImmutableUtils.setIn)(denormalized, [attribute], denormalize(item, entities, itemSchema, bag));
+
+    // If schema has a property called `computed` add it to the
+    // final denormalized object. This property contains a collection
+    // of method to compute data from the final entity.
+    if (schema.hasOwnProperty('computed')) {
+      denormalized = Object.assign({}, denormalized, schema.computed);
+    }
+  });
+
+  return denormalized;
+}
+
+/**
+ * Takes an entity, saves a reference to it in the 'bag' and then denormalizes
+ * it. Saving the reference is necessary for circular dependencies.
+ *
+ * @param   {object|Immutable.Map|number|string} entityOrId
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map}
+ */
+function denormalizeEntity(entityOrId, entities, schema, bag) {
+  var key = schema.getKey();
+
+  var _resolveEntityOrId = resolveEntityOrId(entityOrId, entities, schema);
+
+  var entity = _resolveEntityOrId.entity;
+  var id = _resolveEntityOrId.id;
+
+
+  if (!bag.hasOwnProperty(key)) {
+    bag[key] = {};
+  }
+
+  if (!bag[key].hasOwnProperty(id)) {
+    // Ensure we don't mutate it non-immutable objects
+    var obj = (0, _ImmutableUtils.isImmutable)(entity) ? entity : (0, _merge2.default)({}, entity);
+
+    // Need to set this first so that if it is referenced within the call to
+    // denormalizeObject, it will already exist.
+    bag[key][id] = obj;
+    bag[key][id] = denormalizeObject(obj, entities, schema, bag);
+  }
+
+  return bag[key][id];
+}
+
+/**
+ * Takes an object, array, or id and returns a denormalized copy of it. For
+ * an object or array, the same data type is returned. For an id, an object
+ * will be returned.
+ *
+ * If the passed object is null or undefined or if no schema is provided, the
+ * passed object will be returned.
+ *
+ * @param   {object|Immutable.Map|array|Immutable.list|number|string} obj
+ * @param   {object|Immutable.Map} entities
+ * @param   {Schema} schema
+ * @param   {object} bag
+ * @returns {object|Immutable.Map|array|Immutable.list}
+ */
+function denormalize(obj, entities, schema) {
+  var bag = arguments.length <= 3 || arguments[3] === undefined ? {} : arguments[3];
+
+  if (obj === null || typeof obj === 'undefined' || !(0, _isObject2.default)(schema)) {
+    return obj;
+  }
+
+  if (schema instanceof _EntitySchema2.default) {
+    return denormalizeEntity(obj, entities, schema, bag);
+  } else if (schema instanceof _IterableSchema2.default) {
+    return denormalizeIterable(obj, entities, schema, bag);
+  } else if (schema instanceof _UnionSchema2.default) {
+    return denormalizeUnion(obj, entities, schema, bag);
+  } else {
+    // Ensure we don't mutate it non-immutable objects
+    var entity = (0, _ImmutableUtils.isImmutable)(obj) ? obj : (0, _merge2.default)({}, obj);
+    return denormalizeObject(entity, entities, schema, bag);
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,7 @@ function denormalizeObject(obj, entities, schema, bag) {
     // final denormalized object. This property contains a collection
     // of method to compute data from the final entity.
     if (schema.hasOwnProperty('computed')) {
-      denormalized = Object.assign({}, denormalized, schema.computed);
+      denormalized = Object.assign(denormalized, schema.computed);
     }
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,13 +109,6 @@ function denormalizeObject(obj, entities, schema, bag) {
     var itemSchema = (0, _ImmutableUtils.getIn)(schema, [attribute]);
 
     denormalized = (0, _ImmutableUtils.setIn)(denormalized, [attribute], denormalize(item, entities, itemSchema, bag));
-
-    // If schema has a property called `computed` add it to the
-    // final denormalized object. This property contains a collection
-    // of method to compute data from the final entity.
-    if (schema.hasOwnProperty('computed')) {
-      denormalized = Object.assign(denormalized, schema.computed);
-    }
   });
 
   return denormalized;
@@ -152,6 +145,13 @@ function denormalizeEntity(entityOrId, entities, schema, bag) {
     // denormalizeObject, it will already exist.
     bag[key][id] = obj;
     bag[key][id] = denormalizeObject(obj, entities, schema, bag);
+  }
+
+  // If schema has a property called `computed` add it to the
+  // final denormalized object. This property contains a collection
+  // of method to compute data from the final entity.
+  if (schema.hasOwnProperty('computed')) {
+    bag[key][id] = Object.assign(bag[key][id], schema.computed);
   }
 
   return bag[key][id];

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ function denormalizeObject(obj, entities, schema, bag) {
       // final denormalized object. This property contains a collection
       // of method to compute data from the final entity.
       if (schema.hasOwnProperty('computed')) {
-        denormalized = Object.assign({}, denormalized, schema.computed);
+        denormalized = Object.assign(denormalized, schema.computed);
       }
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,13 @@ function denormalizeObject(obj, entities, schema, bag) {
       const itemSchema = getIn(schema, [attribute]);
 
       denormalized = setIn(denormalized, [attribute], denormalize(item, entities, itemSchema, bag));
+
+      // If schema has a property called `computed` add it to the
+      // final denormalized object. This property contains a collection
+      // of method to compute data from the final entity.
+      if (schema.hasOwnProperty('computed')) {
+        denormalized = Object.assign({}, denormalized, schema.computed);
+      }
     });
 
   return denormalized;

--- a/src/index.js
+++ b/src/index.js
@@ -85,13 +85,6 @@ function denormalizeObject(obj, entities, schema, bag) {
       const itemSchema = getIn(schema, [attribute]);
 
       denormalized = setIn(denormalized, [attribute], denormalize(item, entities, itemSchema, bag));
-
-      // If schema has a property called `computed` add it to the
-      // final denormalized object. This property contains a collection
-      // of method to compute data from the final entity.
-      if (schema.hasOwnProperty('computed')) {
-        denormalized = Object.assign(denormalized, schema.computed);
-      }
     });
 
   return denormalized;
@@ -123,6 +116,13 @@ function denormalizeEntity(entityOrId, entities, schema, bag) {
     // denormalizeObject, it will already exist.
     bag[key][id] = obj;
     bag[key][id] = denormalizeObject(obj, entities, schema, bag);
+  }
+
+  // If schema has a property called `computed` add it to the
+  // final denormalized object. This property contains a collection
+  // of method to compute data from the final entity.
+  if (schema.hasOwnProperty('computed')) {
+    bag[key][id] = Object.assign(bag[key][id], schema.computed);
   }
 
   return bag[key][id];


### PR DESCRIPTION
A small change that I'm using in my project just in case it's interesting. It allows you to create an extra property in the schema definition called `computed` in which you can add methods that are gonna be added to the final denormalized entity. e.g.

```javascript
const project = new Schema('project');
project.define({
  computed: {
    getNumberOfTasks() {
      return this.tasks.length;
    }
  }
});
```

And then, you can use your denormalized entity like this:

```javascript
const project = denormalize(...);
project.getNumberOfTasks();
```