### PR TITLE
Fixes denormalizing a `unionOf` relationship

### DIFF
--- a/src/ImmutableUtils.js
+++ b/src/ImmutableUtils.js
@@ -60,3 +60,18 @@ export function setIn(object, keyPath, value) {
 
   return object;
 }
+
+/**
+ * Moves the union to a property with the appropriate schema name
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @return {any}
+ */
+export function moveUnionToSchema(entity) {
+  if (isImmutable(entity)) {
+    // can't use entity.set(...) to do this in case of an Immutable.Record
+    return { [entity.get('schema')]: entity.get('id') };
+  }
+
+  return Object.assign({}, entity, { [entity.schema]: entity.id });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import EntitySchema from 'normalizr/lib/EntitySchema';
 import UnionSchema from 'normalizr/lib/UnionSchema';
 import merge from 'lodash/merge';
 import isObject from 'lodash/isObject';
-import { isImmutable, getIn, setIn } from './ImmutableUtils';
+import { isImmutable, getIn, setIn, moveUnionToSchema } from './ImmutableUtils';
 
 /**
  * Take either an entity or id and derive the other.
@@ -52,12 +52,13 @@ function denormalizeIterable(items, entities, schema, bag) {
  */
 function denormalizeUnion(entity, entities, schema, bag) {
   const itemSchema = schema.getItemSchema();
-  return denormalize(
-    Object.assign({}, entity, { [entity.schema]: entity.id }),
+  const denormalized = denormalize(
+    moveUnionToSchema(entity),
     entities,
     itemSchema,
     bag
-  )[entity.schema];
+  );
+  return getIn(denormalized, [isImmutable(entity) ? entity.get('schema') : entity.schema]);
 }
 
 /**

--- a/test/immutable.js
+++ b/test/immutable.js
@@ -162,49 +162,103 @@ describe('(Immutable) denormalize', () => {
   });
 
   describe('parsing union schemas', () => {
-    const postSchema = new Schema('posts');
-    const userSchema = new Schema('users');
+    describe('when a schema', () => {
+      const postSchema = new Schema('posts');
+      const userSchema = new Schema('users');
 
-    postSchema.define({
-      user: userSchema,
+      postSchema.define({
+        user: userSchema,
+      });
+
+      const unionItemSchema = unionOf({
+        post: postSchema,
+        user: userSchema,
+      }, { schemaAttribute: 'type' });
+
+      const response = {
+        unionItems: [
+          {
+            id: 1,
+            title: 'Some Post',
+            user: {
+              id: 1,
+              name: 'Dan',
+            },
+            type: 'post',
+          },
+          {
+            id: 2,
+            name: 'Ashley',
+            type: 'user',
+          },
+          {
+            id: 2,
+            title: 'Other Post',
+            type: 'post',
+          },
+        ],
+      };
+
+      const data = immutableNormalize(response.unionItems, arrayOf(unionItemSchema));
+
+      it('should return the original response', () => {
+        const denormalized = data.result.map(item =>
+          denormalize(item, data.entities, unionItemSchema)
+        );
+        expect(fromJS(denormalized)).to.be.eql(fromJS(response.unionItems));
+      });
     });
 
-    const unionItemSchema = unionOf({
-      post: postSchema,
-      user: userSchema,
-    }, { schemaAttribute: 'type' });
+    describe('when defining a relationship', () => {
+      const groupSchema = new Schema('groups');
+      const userSchema = new Schema('users');
 
-    const response = {
-      unionItems: [
-        {
-          id: 1,
-          title: 'Some Post',
-          user: {
+      const member = unionOf({
+        users: userSchema,
+        groups: groupSchema,
+      }, { schemaAttribute: 'type' });
+
+      groupSchema.define({
+        owner: member,
+      });
+
+      const response = {
+        groups: [
+          {
             id: 1,
-            name: 'Dan',
+            owner: {
+              id: 1,
+              type: 'user',
+              name: 'Dan',
+            },
           },
-          type: 'post',
-        },
-        {
-          id: 2,
-          name: 'Ashley',
-          type: 'user',
-        },
-        {
-          id: 2,
-          title: 'Other Post',
-          type: 'post',
-        },
-      ],
-    };
+          {
+            id: 2,
+            owner: {
+              id: 2,
+              type: 'user',
+              name: 'Alice',
+            },
+          },
+          {
+            id: 3,
+            owner: {
+              id: 1,
+              type: 'group',
+              name: 'Teaching',
+            },
+          },
+        ],
+      };
 
-    const data = immutableNormalize(response.unionItems, arrayOf(unionItemSchema));
+      const data = immutableNormalize(response.groups, arrayOf(groupSchema));
 
-    it('should return the original response', () => {
-      const denormalized = data.result.map(item =>
-        denormalize(item, data.entities, unionItemSchema)
-      );
-      expect(fromJS(denormalized)).to.be.eql(fromJS(response.unionItems));
+      it('should return the original response', () => {
+        const denormalized = data.result.map(item =>
+          denormalize(item, data.entities, groupSchema)
+        );
+        expect(fromJS(denormalized)).to.be.deep.eql(fromJS(response.groups));
+      });
     });
   });
 


### PR DESCRIPTION
When using `unionOf` to define a relationship (see example below from normalizr documentation) and the entity is either an `Immutable.Map` or `Immutable.Record` the relationship wouldn’t be de-normalized as expected.

```
const group = new Schema('groups');
const user = new Schema('users');

const member = unionOf({
  users: user,
  groups: group
}, { schemaAttribute: 'type' });

group.define({
  owner: member
});
```