### PR TITLE
Add support for valuesOf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,19 @@ function resolveEntityOrId(entityOrId, entities, schema) {
  */
 function denormalizeIterable(items, entities, schema, bag) {
   const itemSchema = schema.getItemSchema();
+  const isMappable = typeof items.map === 'function';
 
-  return items.map(o => denormalize(o, entities, itemSchema, bag));
+  // Handle arrayOf iterables
+  if (isMappable) {
+    return items.map(o => denormalize(o, entities, itemSchema, bag));
+  }
+
+  // Handle valuesOf iterables
+  const denormalized = {};
+  Object.keys(items).forEach((key) => {
+    denormalized[key] = denormalize(items[key], entities, itemSchema, bag);
+  });
+  return denormalized;
 }
 
 /**


### PR DESCRIPTION
Adds support for the [`valuesOf`](https://github.com/paularmstrong/normalizr#valuesofschema-options) iterable type, so that schemas that contain maps of items defined by another schema can be denormalized.